### PR TITLE
 avoid a unexpected operator error when automatically fixing root password

### DIFF
--- a/fixup-root-passwords.sh
+++ b/fixup-root-passwords.sh
@@ -3,6 +3,6 @@ FNAME=$1
 OZ_DEBUG=$2
 NEW_ROOT="`pwgen -s 24 -1`"
 CUR_ROOT=`grep rootpw $FNAME | awk -F'[<|>]' '{print $3}'`
-if [ "$CUR_ROOT" == 'ROOT-PW_CHANGE-ME!!!' ]; then
+if [ "$CUR_ROOT" = 'ROOT-PW_CHANGE-ME!!!' ]; then
     sed 's/ROOT-PW_CHANGE-ME!!!/'$NEW_ROOT'/g' $FNAME
 fi


### PR DESCRIPTION
Fixing bash syntax to avoid a unexpected operator error when automatically fixing root password
